### PR TITLE
Removed backtick notation for subcommands.

### DIFF
--- a/merge.sh
+++ b/merge.sh
@@ -14,8 +14,8 @@ FIRST_FILE=$1
 head -1 $FIRST_FILE | sed "s/^/stitch,coupe,observer,id/" > $OUTPUT
 for f in $@; do
     echo "Processing file $f ..."
-    STITCH=`echo $f | cut -f1 -d_`
-    COUPE=`echo $f | cut -f2 -d_`
-    OBSERVER=`echo $f | cut -f3 -d_ | cut -f1 -d.`
+    STITCH=$(echo $f | cut -f1 -d_)
+    COUPE=$(echo $f | cut -f2 -d_)
+    OBSERVER=$(echo $f | cut -f3 -d_ | cut -f1 -d.)
     tail -n+2 $f | sed "s/^/$STITCH,$COUPE,$OBSERVER,/" >> $OUTPUT
 done


### PR DESCRIPTION
Use of backticks for subcommands is currently not recommended in shell scripting (see: https://unix.stackexchange.com/a/126928). Replaced this with alternative $(...) notation.